### PR TITLE
---Add support for grant_installation---

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,8 +239,11 @@ dependencies = [
  "anyhow",
  "async-trait",
  "ctor",
+ "inbox",
  "jsonrpsee",
  "log",
+ "messaging",
+ "registry",
  "serde",
  "thiserror",
  "tokio",
@@ -781,6 +784,10 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 [[package]]
 name = "registry"
 version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "jsonrpsee",
+]
 
 [[package]]
 name = "route-recognizer"

--- a/README.md
+++ b/README.md
@@ -28,3 +28,4 @@ $ docker build . -t xps-gateway:1
 ```bash
 $ cargo test
 ```
+

--- a/registry/Cargo.toml
+++ b/registry/Cargo.toml
@@ -6,3 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+jsonrpsee = { version = "0.21", features = ["macros", "server", "client-core"] }
+anyhow = "1"

--- a/registry/src/lib.rs
+++ b/registry/src/lib.rs
@@ -1,3 +1,8 @@
+pub mod registry;
+pub mod types;
+
+pub struct XpsRegistry;
+
 pub fn add(left: usize, right: usize) -> usize {
     left + right
 }

--- a/registry/src/registry.rs
+++ b/registry/src/registry.rs
@@ -1,0 +1,20 @@
+use crate::types::{GrantInstallationResult, Signature};
+
+impl super::XpsRegistry {
+    pub async fn grant_installation(
+        &self,
+        _did: String,
+        _name: String,
+        _value: String,
+        _signature: Signature,
+    ) -> Result<GrantInstallationResult, anyhow::Error> {
+        // if all good, invoke the call to the registry.
+        // stub -
+        let result = GrantInstallationResult {
+            status: "my-status".to_string(),
+            message: "my message".to_string(),
+            transaction: "my transaction".to_string(),
+        };
+        Ok(result)
+    }
+}

--- a/registry/src/types.rs
+++ b/registry/src/types.rs
@@ -1,0 +1,14 @@
+pub struct Signature {
+    /// Signature of V
+    pub v: i64,
+    /// Signature of R
+    pub r: Vec<u8>,
+    /// Signature of S
+    pub s: Vec<u8>,
+}
+
+pub struct GrantInstallationResult {
+    pub status: String,
+    pub message: String,
+    pub transaction: String,
+}

--- a/xps-gateway/Cargo.toml
+++ b/xps-gateway/Cargo.toml
@@ -18,3 +18,6 @@ jsonrpsee = { version = "0.21", features = ["macros", "server", "client-core"] }
 anyhow = "1"
 thiserror = "1"
 ctor = "0.2"
+registry= { path = "../registry" }
+messaging= { path = "../messaging" }
+inbox= { path = "../inbox" }

--- a/xps-gateway/src/lib.rs
+++ b/xps-gateway/src/lib.rs
@@ -2,10 +2,9 @@ mod rpc;
 mod types;
 mod util;
 
+pub use crate::rpc::{XpsMethods, XpsServer};
 use anyhow::Result;
 use jsonrpsee::server::Server;
-
-pub use crate::rpc::{XpsMethods, XpsServer};
 
 /// Entrypoint for the xps Gateway
 pub async fn run() -> Result<()> {
@@ -14,7 +13,10 @@ pub async fn run() -> Result<()> {
     // a port of 0 allows the OS to choose an open port
     let server = Server::builder().build("127.0.0.1:0").await?;
     let addr = server.local_addr()?;
-    let handle = server.start(rpc::XpsMethods.into_rpc());
+    let xps_methods = XpsMethods {
+        registry: registry::XpsRegistry {},
+    };
+    let handle = server.start(xps_methods.into_rpc());
 
     log::info!("Server Started at {addr}");
     handle.stopped().await;

--- a/xps-gateway/src/rpc/api.rs
+++ b/xps-gateway/src/rpc/api.rs
@@ -2,7 +2,7 @@
 
 use jsonrpsee::{proc_macros::rpc, types::ErrorObjectOwned};
 
-use crate::types::Message;
+use crate::types::{GrantInstallationResult, Message, Signature};
 
 /// XPS JSON-RPC Interface Methods
 #[rpc(server, client, namespace = "xps")]
@@ -10,4 +10,13 @@ pub trait Xps {
     // Placeholder for send_message, see [the discussion](https://github.com/xmtp/xps-gateway/discussions/11)
     #[method(name = "sendMessage")]
     async fn send_message(&self, _message: Message) -> Result<(), ErrorObjectOwned>;
+
+    #[method(name = "grantInstallation")]
+    async fn grant_installation(
+        &self,
+        did: String,
+        name: String,
+        value: String,
+        signature: Signature,
+    ) -> Result<GrantInstallationResult, ErrorObjectOwned>;
 }

--- a/xps-gateway/src/rpc/methods.rs
+++ b/xps-gateway/src/rpc/methods.rs
@@ -5,7 +5,7 @@ use super::api::*;
 use async_trait::async_trait;
 use jsonrpsee::types::ErrorObjectOwned;
 
-use crate::types::Message;
+use crate::types::{GrantInstallationResult, Message, Signature};
 
 /// Gateway Methods for XPS
 pub struct XpsMethods;
@@ -16,5 +16,24 @@ impl XpsServer for XpsMethods {
         //TODO: Stub for sendMessage, ref: [discussion](https://github.com/xmtp/xps-gateway/discussions/11)
         log::debug!("xps_sendMessage called");
         todo!();
+    }
+
+    async fn grant_installation(
+        &self,
+        _did: String,
+        _name: String,
+        _value: String,
+        _signature: Signature,
+    ) -> Result<GrantInstallationResult, ErrorObjectOwned> {
+        /*if name.len() > 32 {
+            Err(GrantInstallationResult {})
+        }*/
+
+        let result = GrantInstallationResult {
+            status: "my-status".to_string(),
+            message: "my message".to_string(),
+            transaction: "my transaction".to_string(),
+        };
+        Ok(result)
     }
 }

--- a/xps-gateway/src/rpc/methods.rs
+++ b/xps-gateway/src/rpc/methods.rs
@@ -3,12 +3,15 @@
 use super::api::*;
 
 use async_trait::async_trait;
-use jsonrpsee::types::ErrorObjectOwned;
+use jsonrpsee::types::{ErrorObject, ErrorObjectOwned};
 
 use crate::types::{GrantInstallationResult, Message, Signature};
+use registry::XpsRegistry;
 
 /// Gateway Methods for XPS
-pub struct XpsMethods;
+pub struct XpsMethods {
+    pub registry: XpsRegistry,
+}
 
 #[async_trait]
 impl XpsServer for XpsMethods {
@@ -20,20 +23,52 @@ impl XpsServer for XpsMethods {
 
     async fn grant_installation(
         &self,
-        _did: String,
-        _name: String,
-        _value: String,
-        _signature: Signature,
+        did: String,
+        name: String,
+        value: String,
+        signature: Signature,
     ) -> Result<GrantInstallationResult, ErrorObjectOwned> {
-        /*if name.len() > 32 {
-            Err(GrantInstallationResult {})
-        }*/
-
-        let result = GrantInstallationResult {
-            status: "my-status".to_string(),
-            message: "my message".to_string(),
-            transaction: "my transaction".to_string(),
+        // perform data validation on the request parameters.
+        if name.len() > 32 {
+            return Err(ErrorObject::borrowed(
+                -31001,
+                "name field was longer than 32 bytes",
+                None,
+            ));
         };
-        Ok(result)
+        if value.len() > 4096 {
+            return Err(ErrorObject::borrowed(
+                -31002,
+                "value field was longer than 4096 bytes",
+                None,
+            ));
+        }
+
+        // if all good, invoke the call to the registry.
+        let result = self
+            .registry
+            .grant_installation(
+                did,
+                name,
+                value,
+                registry::types::Signature {
+                    v: signature.v,
+                    r: signature.r,
+                    s: signature.s,
+                },
+            )
+            .await
+            .map_err(into_error_object)?;
+
+        Ok(GrantInstallationResult {
+            status: result.status,
+            message: result.message,
+            transaction: result.transaction,
+        })
     }
+}
+
+/// Convenience function to convert an anyhow::Error into an ErrorObjectOwned.
+fn into_error_object(error: anyhow::Error) -> ErrorObjectOwned {
+    ErrorObjectOwned::owned(-31000, error.to_string(), None::<()>)
 }

--- a/xps-gateway/src/types.rs
+++ b/xps-gateway/src/types.rs
@@ -15,3 +15,26 @@ pub struct Message {
     /// Signature of S
     s: Vec<u8>,
 }
+
+#[derive(Serialize, Deserialize)]
+pub struct Signature {
+    /// Signature of V
+    #[serde(rename = "V")]
+    v: i64,
+    /// Signature of R
+    #[serde(rename = "R")]
+    r: Vec<u8>,
+    /// Signature of S
+    #[serde(rename = "S")]
+    s: Vec<u8>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct GrantInstallationResult {
+    #[serde(rename = "status")]
+    pub status: String,
+    #[serde(rename = "message")]
+    pub message: String,
+    #[serde(rename = "tx")]
+    pub transaction: String,
+}

--- a/xps-gateway/src/types.rs
+++ b/xps-gateway/src/types.rs
@@ -1,5 +1,8 @@
 use serde::{Deserialize, Serialize};
 
+// The types defined here are paret of the model for RPC calls. These are different from the underlying crates implementation data structure.
+// underlying types, for instance, won't be serialized.
+
 /// A message sent to a conversation
 #[derive(Serialize, Deserialize)]
 pub struct Message {
@@ -20,13 +23,13 @@ pub struct Message {
 pub struct Signature {
     /// Signature of V
     #[serde(rename = "V")]
-    v: i64,
+    pub v: i64,
     /// Signature of R
     #[serde(rename = "R")]
-    r: Vec<u8>,
+    pub r: Vec<u8>,
     /// Signature of S
     #[serde(rename = "S")]
-    s: Vec<u8>,
+    pub s: Vec<u8>,
 }
 
 #[derive(Serialize, Deserialize, Clone)]


### PR DESCRIPTION
## What ?
This PR adds support for registering a new installation.

## Design considerations
The `xps-gateway` is the executable endpoint, that manages the rpc endpoint. It will setup an rpc server that would listen for incoming requests and perform input validation. Valid requests would be forwarded to the inbox / messaging / registry crates for method-specific implementation.

## Requirements
This PR followed the design details in https://github.com/xmtp/xps-gateway/issues/22; discussion in https://github.com/xmtp/xps-gateway/discussions/13 and https://github.com/xmtp/libxmtp/discussions/274
