### PR TITLE
46, 47: force prod ci build, upgrade codecov plugin

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Generate code coverage
         run: RUST_LOG=xps_gateway=info,registry=info,inbox=info,messaging=info,gateway_types=info cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info

--- a/.github/workflows/prod-ci-image.yml
+++ b/.github/workflows/prod-ci-image.yml
@@ -1,4 +1,4 @@
-name: Build Dev Image CI
+name: Build Prod Image CI
 
 on:
   workflow_dispatch:
@@ -22,10 +22,11 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      - name: Build CI
+      - name: Build Prod Image CI
         uses: docker/build-push-action@v3
         with:
           context: .
+          file:    prod/Dockerfile
           platforms: linux/amd64
           push: false
           build-args: |


### PR DESCRIPTION
closes #46 

related to #47 


This sets the build to fail if the production container does not build