### PR TITLE
grant_installation

### DIFF
--- a/gateway-types/src/lib.rs
+++ b/gateway-types/src/lib.rs
@@ -20,3 +20,24 @@ pub struct Message {
     /// Signature of S
     pub s: Vec<u8>,
 }
+
+/// GrantInstallationResult represents the result of a grant installation operation in the DID registry.
+///
+/// This struct encapsulates the outcome of an attempt to grant an installation,
+/// providing details about the operation's status, a descriptive message, and the
+/// transaction identifier associated with the blockchain transaction.
+///
+/// # Fields
+/// * `status` - A `String` indicating the outcome status of the operation. Typically, this
+///   would be values like "Success" or "Failure".
+/// * `message` - A `String` providing more detailed information about the operation. This
+///   can be a success message, error description, or any other relevant information.
+/// * `transaction` - A `String` representing the unique identifier of the transaction on the
+///   blockchain. This can be used to track the transaction in a blockchain explorer.
+///
+#[derive(Serialize, Deserialize, Clone)]
+pub struct GrantInstallationResult {
+    pub status: String,
+    pub message: String,
+    pub transaction: String,
+}

--- a/registry/src/lib.rs
+++ b/registry/src/lib.rs
@@ -3,7 +3,7 @@ pub mod error;
 use std::str::FromStr;
 
 use error::ContactOperationError;
-use ethers::types::U256;
+use ethers::types::{H160, U256};
 use ethers::{core::types::Signature, providers::Middleware, types::Address};
 use gateway_types::GrantInstallationResult;
 use lib_didethresolver::{
@@ -24,6 +24,13 @@ where
         Self { registry }
     }
 
+    fn resolve_did_address(&self, did: String) -> Result<H160, ContactOperationError<M>> {
+        // for now, we will just assume the DID is a valid ethereum wallet address
+        // TODO: Parse or resolve the actual DID
+        let address = Address::from_str(&did)?;
+        Ok(address)
+    }
+
     pub async fn grant_installation(
         &self,
         did: String,
@@ -32,11 +39,7 @@ where
         signature: Signature,
         validity: U256,
     ) -> Result<GrantInstallationResult, ContactOperationError<M>> {
-        // for now, we will just assume the DID is a valid ethereum wallet address
-        // TODO: Parse or resolve the actual DID
-        // Note that it should be refactored along with revoke_installation that uses the very
-        // same logic.
-        let address = Address::from_str(&did)?;
+        let address = self.resolve_did_address(did)?;
         let attribute: [u8; 32] = Attribute::from(name).into();
         log::debug!(
             "setting attribute {:#?}",
@@ -71,9 +74,7 @@ where
         value: Vec<u8>,
         signature: Signature,
     ) -> Result<(), ContactOperationError<M>> {
-        // for now, we will just assume the DID is a valid ethereum wallet address
-        // TODO: Parse or resolve the actual DID
-        let address = Address::from_str(&did)?;
+        let address = self.resolve_did_address(did)?;
         let attribute: [u8; 32] = Attribute::from(name).into();
         log::debug!(
             "Revoking attribute {:#?}",

--- a/registry/src/lib.rs
+++ b/registry/src/lib.rs
@@ -30,6 +30,7 @@ where
         name: XmtpAttribute,
         value: Vec<u8>,
         signature: Signature,
+        validity: U256,
     ) -> Result<GrantInstallationResult, ContactOperationError<M>> {
         // for now, we will just assume the DID is a valid ethereum wallet address
         // TODO: Parse or resolve the actual DID
@@ -51,7 +52,7 @@ where
                 signature.s.into(),
                 attribute,
                 value.into(),
-                U256::from(1),
+                validity,
             )
             .send()
             .await?

--- a/xps-gateway/src/rpc/api.rs
+++ b/xps-gateway/src/rpc/api.rs
@@ -4,6 +4,7 @@ use ethers::core::types::Signature;
 use ethers::prelude::*;
 use jsonrpsee::{proc_macros::rpc, types::ErrorObjectOwned};
 
+use gateway_types::GrantInstallationResult;
 use gateway_types::Message;
 use lib_didethresolver::types::XmtpAttribute;
 
@@ -13,6 +14,103 @@ pub trait Xps {
     // Placeholder for send_message, see [the discussion](https://github.com/xmtp/xps-gateway/discussions/11)
     #[method(name = "sendMessage")]
     async fn send_message(&self, _message: Message) -> Result<(), ErrorObjectOwned>;
+
+    /// # Documentation for JSON RPC Endpoint: `grantInstallation`
+    ///
+    /// ## Overview
+    ///
+    /// The `grantInstallation` method is used to register an installation on the network and associate the installation with a concrete identity.
+    ///
+    /// ## JSON RPC Endpoint Specification
+    ///
+    /// ### Method Name
+    /// `grantInstallation`
+    ///
+    /// ### Request Parameters
+    /// did: string
+    /// name: String,
+    /// value: String,
+    /// signature: Signature,
+    ///
+    /// ### Request Format
+    /// ```json
+    /// {
+    ///   "jsonrpc": "2.0",
+    ///   "method": "status",
+    ///   "id": 1
+    /// }
+    /// ```
+
+    /// - `jsonrpc`: Specifies the version of the JSON RPC protocol being used. Always "2.0".
+    /// - `method`: The name of the method being called. Here it is "grantInstallation".
+    /// - `id`: A unique identifier established by the client that must be number or string. Used for correlating the response with the request.
+
+    /// ### Response Format
+    /// The response will typically include the result of the operation or an error if the operation was unsuccessful.
+
+    /// #### Success Response
+    /// ```json
+    /// {
+    ///   "jsonrpc": "2.0",
+    ///   "result": "OK",
+    ///   "id": 1
+    /// }
+    /// ```
+    ///
+    /// - `result`: Contains data related to the success of the operation. The nature of this data can vary based on the implementation.
+    ///
+    /// #### Error Response
+    /// ```json
+    /// {
+    ///   "jsonrpc": "2.0",
+    ///   "error": {
+    ///     "code": <error_code>,
+    ///     "message": "<error_message>"
+    ///   },
+    ///   "id": 1
+    /// }
+    /// ```
+    ///
+    /// - `error`: An object containing details about the error.
+    ///   - `code`: A numeric error code.
+    ///   - `message`: A human-readable string describing the error.
+    ///
+    /// ### Example Usage
+    ///
+    /// #### Request
+    /// ```json
+    /// {
+    ///   "jsonrpc": "2.0",
+    ///   "method": "status",
+    ///   "id": 42
+    /// }
+    /// ```
+    ///
+    /// #### Response
+    /// ```json
+    /// {
+    ///   "jsonrpc": "2.0",
+    ///   "result": "OK",
+    ///   "id": 42
+    /// }
+    /// ```
+    ///
+    /// ### Command Line Example
+    /// ```bash
+    /// $ $ curl -H "Content-Type: application/json" -d '{"id":7000, "jsonrpc":"2.0", "method":"xps_status"}' http:///localhost:34695
+    /// {"jsonrpc":"2.0","result":"OK","id":7000}
+    /// ```
+    ///
+    /// ### Notes
+    /// - The system should have proper error handling to deal with invalid requests, unauthorized access, and other potential issues.
+    #[method(name = "grantInstallation")]
+    async fn grant_installation(
+        &self,
+        did: String,
+        name: XmtpAttribute,
+        value: Vec<u8>,
+        signature: Signature,
+    ) -> Result<GrantInstallationResult, ErrorObjectOwned>;
 
     /// # Documentation for JSON RPC Endpoint: `revoke_installation`
     ///

--- a/xps-gateway/src/rpc/methods.rs
+++ b/xps-gateway/src/rpc/methods.rs
@@ -12,6 +12,7 @@ use gateway_types::GrantInstallationResult;
 use jsonrpsee::types::ErrorObjectOwned;
 use lib_didethresolver::types::XmtpAttribute;
 use rand::{rngs::StdRng, SeedableRng};
+use std::sync::Arc;
 use thiserror::Error;
 
 use gateway_types::Message;
@@ -21,6 +22,7 @@ use registry::{error::ContactOperationError, ContactOperations};
 pub struct XpsMethods<P: Middleware + 'static> {
     contact_operations: ContactOperations<GatewaySigner<P>>,
     pub wallet: LocalWallet,
+    pub signer: Arc<GatewaySigner<P>>,
 }
 
 impl<P: Middleware> XpsMethods<P> {
@@ -28,6 +30,7 @@ impl<P: Middleware> XpsMethods<P> {
         Self {
             contact_operations: ContactOperations::new(context.registry.clone()),
             wallet: LocalWallet::new(&mut StdRng::from_entropy()),
+            signer: context.signer.clone(),
         }
     }
 }
@@ -52,10 +55,14 @@ impl<P: Middleware + 'static> XpsServer for XpsMethods<P> {
         value: Vec<u8>,
         signature: Signature,
     ) -> Result<GrantInstallationResult, ErrorObjectOwned> {
-        log::debug!("xps_revokeInstallation called");
+        log::debug!("xps_grantInstallation called");
+        let block_number = self.signer.get_block_number().await.unwrap();
+        let validity_period: U64 = U64::from(60 * 60 * 24 * 365 / 5); // number of round in one year, assuming 5-second round.
+        let validity = block_number + validity_period;
+
         let result = self
             .contact_operations
-            .grant_installation(did, name, value, signature)
+            .grant_installation(did, name, value, signature, U256::from(validity.as_u64()))
             .await
             .map_err(RpcError::from)?;
 

--- a/xps-gateway/src/rpc/methods.rs
+++ b/xps-gateway/src/rpc/methods.rs
@@ -8,6 +8,7 @@ use jsonrpsee::types::error::ErrorCode;
 use async_trait::async_trait;
 use ethers::prelude::*;
 use ethers::{core::types::Signature, providers::Middleware};
+use gateway_types::GrantInstallationResult;
 use jsonrpsee::types::ErrorObjectOwned;
 use lib_didethresolver::types::XmtpAttribute;
 use rand::{rngs::StdRng, SeedableRng};
@@ -42,6 +43,23 @@ impl<P: Middleware + 'static> XpsServer for XpsMethods<P> {
     async fn status(&self) -> Result<String, ErrorObjectOwned> {
         log::debug!("xps_status called");
         Ok("OK".to_string())
+    }
+
+    async fn grant_installation(
+        &self,
+        did: String,
+        name: XmtpAttribute,
+        value: Vec<u8>,
+        signature: Signature,
+    ) -> Result<GrantInstallationResult, ErrorObjectOwned> {
+        log::debug!("xps_revokeInstallation called");
+        let result = self
+            .contact_operations
+            .grant_installation(did, name, value, signature)
+            .await
+            .map_err(RpcError::from)?;
+
+        Ok(result)
     }
 
     async fn revoke_installation(

--- a/xps-gateway/tests/integration_test.rs
+++ b/xps-gateway/tests/integration_test.rs
@@ -9,7 +9,8 @@ use lib_didethresolver::{
 };
 use xps_gateway::rpc::XpsClient;
 
-use ethers::types::{Address, U256};
+use ethers::middleware::Middleware;
+use ethers::types::{Address, U256, U64};
 use gateway_types::Message;
 
 use integration_util::*;
@@ -46,6 +47,69 @@ async fn test_wallet_address() -> Result<(), Error> {
     with_xps_client(None, |client, _, _, _| async move {
         let result = client.wallet_address().await?;
         assert_ne!(result, Address::zero());
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+async fn test_grant_installation() -> Result<(), Error> {
+    with_xps_client(None, |client, context, resolver, anvil| async move {
+        let wallet: LocalWallet = anvil.keys()[3].clone().into();
+        let me = get_user(&anvil, 3).await;
+        let name = *b"xmtp/installation/hex           ";
+        let value = b"02b97c30de767f084ce3080168ee293053ba33b235d7116a3263d29f1450936b71";
+
+        let attribute = XmtpAttribute {
+            purpose: XmtpKeyPurpose::Installation,
+            encoding: KeyEncoding::Hex,
+        };
+
+        let block_number = context.signer.get_block_number().await.unwrap();
+        let validity_period: U64 = U64::from(60 * 60 * 24 * 365 / 5); // number of round in one year, assuming 5-second round.
+        let validity = block_number + validity_period;
+
+        let signature = wallet
+            .sign_attribute(
+                &context.registry,
+                name,
+                value.to_vec(),
+                U256::from(validity.as_u64()),
+            )
+            .await?;
+
+        client
+            .grant_installation(
+                format!("0x{}", hex::encode(me.address())),
+                attribute,
+                value.to_vec(),
+                signature,
+            )
+            .await?;
+
+        let doc = resolver
+            .resolve_did(me.address(), None)
+            .await
+            .unwrap()
+            .document;
+
+        assert_eq!(doc.verification_method.len(), 2);
+        assert_eq!(
+            doc.verification_method[0].id,
+            DidUrl::parse(format!(
+                "did:ethr:0x{}#controller",
+                hex::encode(me.address())
+            ))
+            .unwrap()
+        );
+        assert_eq!(
+            doc.verification_method[1].id,
+            DidUrl::parse(format!(
+                "did:ethr:0x{}?meta=installation#xmtp-0",
+                hex::encode(me.address())
+            ))
+            .unwrap()
+        );
         Ok(())
     })
     .await


### PR DESCRIPTION
## What ?
This PR adds support for registering a new installation.

## Design considerations
The `xps-gateway` is the executable endpoint, that manages the rpc endpoint. It will setup an rpc server that would listen for incoming requests and perform input validation. Valid requests would be forwarded to the inbox / messaging / registry crates for method-specific implementation.

## Requirements
This PR followed the design details in https://github.com/xmtp/xps-gateway/issues/22; discussion in https://github.com/xmtp/xps-gateway/discussions/13 and https://github.com/xmtp/libxmtp/discussions/274
