### PR TITLE
Add nonce JSON-RPC endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2969,6 +2969,7 @@ name = "registry"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "ctor",
  "ethers",
  "lib-didethresolver",
  "log",
@@ -2976,6 +2977,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "xps-types",
 ]
 

--- a/lib-xps/src/rpc/api.rs
+++ b/lib-xps/src/rpc/api.rs
@@ -517,14 +517,90 @@ pub trait Xps {
     #[method(name = "status")]
     async fn status(&self) -> Result<String, ErrorObjectOwned>;
 
+    /// ### Documentation for JSON RPC Endpoint: `xps_walletAddress`
+    /// ---
+    /// #### Endpoint Name: `xps_walletAddress`
+    /// #### Description:
+    /// The `xps_walletAddress` endpoint retrieves the current Wallet Address of the internal wallet managed by the server. This endpoint is essential for applications that need to display or monitor the wallet, especially in the context of cryptocurrency transactions or account management.
+    /// #### Request:
+    /// - **Method:** `POST`
+    /// - **URL:** `/rpc/v1/walletAddress`
+    /// - **Headers:**
+    /// - `Content-Type: application/json`
+    /// - **Body:**
+    /// - **JSON Object:**
+    ///     - `jsonrpc`: `"2.0"`
+    ///     - `method`: `"xps_walletAddress"`
+    ///     - `params`: Array (optional parameters as required)
+    ///     - `id`: Request identifier (integer or string)
+    /// **Example Request Body:**
+    /// ```json
+    /// {
+    /// "jsonrpc": "2.0",
+    /// "method": "xps_walletAddress",
+    /// "params": [],
+    /// "id": 1
+    /// }
+    /// ```
+    /// #### Response:
+    /// - **Success Status Code:** `200 OK`
+    /// - **Error Status Codes:**
+    /// - `400 Bad Request` - Invalid request format or parameters.
+    /// - `500 Internal Server Error` - Server or wallet-related error.
+    /// **Success Response Body:**
+    /// ```json
+    /// {
+    /// "jsonrpc": "2.0",
+    /// "result": "0x0000000000000000000000000000000000000000",
+    /// "id": 1
+    /// }
+    /// ```
+    /// **Error Response Body:**
+    /// ```json
+    /// {
+    /// "jsonrpc": "2.0",
+    /// "error": {
+    ///     "code": -32602,
+    ///     "message": "Invalid parameters"
+    /// },
+    /// "id": 1
+    /// }
+    /// ```
+    /// #### Error Handling:
+    /// - **Invalid Parameters:** Check if the request body is properly formatted and includes valid parameters.
+    /// - **Wallet or Server Errors:** Ensure that the server and wallet are operational. Consult server logs for detailed error information.
+    /// #### Security Considerations:
+    /// - **Authentication and Authorization:** Implement robust authentication and authorization checks to ensure only authorized users can access wallet balance information.
+    /// - **Secure Communication:** Utilize HTTPS to encrypt data in transit and prevent eavesdropping.
+    /// #### Usage Example:
+    /// ```javascript
+    /// const requestBody = {
+    /// jsonrpc: "2.0",
+    /// method: "xps_walletAddress",
+    /// params: [],
+    /// id: 1
+    /// };
+    /// fetch('https://server.example.com/rpc/v1/walletAddress', {
+    /// method: 'POST',
+    /// headers: {
+    ///     'Content-Type': 'application/json'
+    /// },
+    /// body: JSON.stringify(requestBody)
+    /// })
+    /// .then(response => response.json())
+    /// .then(data => console.log('Wallet Balance:', data.result))
+    /// .catch(error => console.error('Error:', error));
+    /// ```
+    /// </div>
+    /// ```
     #[method(name = "walletAddress")]
     async fn wallet_address(&self) -> Result<Address, ErrorObjectOwned>;
 
-    /// ### Documentation for JSON RPC Endpoint: `balance`
+    /// ### Documentation for JSON RPC Endpoint: `xps_balance`
     /// ---
-    /// #### Endpoint Name: `balance`
+    /// #### Endpoint Name: `xps_balance`
     /// #### Description:
-    /// The `balance` endpoint retrieves the current balance of the internal wallet managed by the server. This endpoint is essential for applications that need to display or monitor the wallet's balance, especially in the context of cryptocurrency transactions or account management.
+    /// The `xps_balance` endpoint retrieves the current balance of the internal wallet managed by the server. This endpoint is essential for applications that need to display or monitor the wallet's balance, especially in the context of cryptocurrency transactions or account management.
     /// #### Request:
     /// - **Method:** `POST`
     /// - **URL:** `/rpc/v1/balance`
@@ -533,14 +609,14 @@ pub trait Xps {
     /// - **Body:**
     /// - **JSON Object:**
     ///     - `jsonrpc`: `"2.0"`
-    ///     - `method`: `"balance"`
+    ///     - `method`: `"xps_balance"`
     ///     - `params`: Array (optional parameters as required)
     ///     - `id`: Request identifier (integer or string)
     /// **Example Request Body:**
     /// ```json
     /// {
     /// "jsonrpc": "2.0",
-    /// "method": "balance",
+    /// "method": "xps_balance",
     /// "params": [],
     /// "id": 1
     /// }
@@ -582,7 +658,7 @@ pub trait Xps {
     /// ```javascript
     /// const requestBody = {
     /// jsonrpc: "2.0",
-    /// method: "balance",
+    /// method: "xps_balance",
     /// params: [],
     /// id: 1
     /// };
@@ -601,4 +677,88 @@ pub trait Xps {
     /// ```
     #[method(name = "balance")]
     async fn balance(&self) -> Result<WalletBalance, ErrorObjectOwned>;
+
+    /// ### Documentation for JSON RPC Endpoint: `xps_nonce`
+    /// ---
+    /// #### Endpoint Name: `nonce`
+    /// #### Description:
+    /// The `xps_nonce` endpoint retrieves the nonce for `address` in the [`DIDRegistry`]. This is
+    /// needed for signing payloads for DID Registry meta transactions.
+
+    /// #### Request:
+    /// - **Method:** `POST`
+    /// - **URL:** `/rpc/v1/nonce`
+    /// - **Headers:**
+    /// - `Content-Type: application/json`
+    /// - **Body:**
+    /// - **JSON Object:**
+    ///     - `jsonrpc`: `"2.0"`
+    ///     - `method`: `"xps_nonce"`
+    ///     - `params`: Array (optional parameters as required)
+    ///     - `id`: Request identifier (integer or string)
+    /// **Example Request Body:**
+    /// ```json
+    /// {
+    /// "jsonrpc": "2.0",
+    /// "method": "xps_nonce",
+    /// "params": ["0x0000000000000000000000000000000000000000"],
+    /// "id": 1
+    /// }
+    /// ```
+    /// #### Response:
+    /// - **Success Status Code:** `200 OK`
+    /// - **Error Status Codes:**
+    /// - `400 Bad Request` - Invalid request format or parameters.
+    /// - `500 Internal Server Error` - Server or wallet-related error.
+    /// **Success Response Body:**
+    /// ```json
+    /// {
+    /// "jsonrpc": "2.0",
+    /// "result": {
+    ///     "nonce": 0
+    /// },
+    /// "id": 1
+    /// }
+    /// ```
+    /// **Error Response Body:**
+    /// ```json
+    /// {
+    /// "jsonrpc": "2.0",
+    /// "error": {
+    ///     "code": -32602,
+    ///     "message": "Invalid parameters"
+    /// },
+    /// "id": 1
+    /// }
+    /// ```
+    /// #### Error Handling:
+    /// - **Invalid Parameters:** Check if the request body is properly formatted and includes valid parameters.
+    /// - **Wallet or Server Errors:** Ensure that the server and wallet are operational. Consult server logs for detailed error information.
+    /// #### Security Considerations:
+    /// - **Authentication and Authorization:** Implement robust authentication and authorization checks to ensure only authorized users can access wallet balance information.
+    /// - **Secure Communication:** Utilize HTTPS to encrypt data in transit and prevent eavesdropping.
+    /// #### Usage Example:
+    /// ```javascript
+    /// const requestBody = {
+    /// jsonrpc: "2.0",
+    /// method: "xps_nonce",
+    /// params: ["0x0000000000000000000000000000000000000000"],
+    /// id: 1
+    /// };
+    /// fetch('https://server.example.com/rpc/v1/nonce', {
+    /// method: 'POST',
+    /// headers: {
+    ///     'Content-Type': 'application/json'
+    /// },
+    /// body: JSON.stringify(requestBody)
+    /// })
+    /// .then(response => response.json())
+    /// .then(data => console.log('Wallet Balance:', data.result))
+    /// .catch(error => console.error('Error:', error));
+    /// ```
+    /// </div>
+    /// ```
+
+    #[method(name = "nonce")]
+    async fn nonce(&self, did: String) -> Result<U256, ErrorObjectOwned>;
 }

--- a/lib-xps/src/rpc/api.rs
+++ b/lib-xps/src/rpc/api.rs
@@ -551,7 +551,7 @@ pub trait Xps {
     /// ```json
     /// {
     /// "jsonrpc": "2.0",
-    /// "result": "0x0000000000000000000000000000000000000000",
+    /// "result": "0xce90a7949bb78892f159f428d0dc23a8e3584d75",
     /// "id": 1
     /// }
     /// ```
@@ -701,7 +701,7 @@ pub trait Xps {
     /// {
     /// "jsonrpc": "2.0",
     /// "method": "xps_nonce",
-    /// "params": ["0x0000000000000000000000000000000000000000"],
+    /// "params": ["0xce90a7949bb78892f159f428d0dc23a8e3584d75"],
     /// "id": 1
     /// }
     /// ```
@@ -742,7 +742,7 @@ pub trait Xps {
     /// const requestBody = {
     /// jsonrpc: "2.0",
     /// method: "xps_nonce",
-    /// params: ["0x0000000000000000000000000000000000000000"],
+    /// params: ["0xce90a7949bb78892f159f428d0dc23a8e3584d75"],
     /// id: 1
     /// };
     /// fetch('https://server.example.com/rpc/v1/nonce', {

--- a/lib-xps/src/rpc/methods.rs
+++ b/lib-xps/src/rpc/methods.rs
@@ -145,6 +145,16 @@ impl<P: Middleware + 'static> XpsServer for XpsMethods<P> {
             .map_err(RpcError::from)?;
         Ok(result)
     }
+
+    async fn nonce(&self, did: String) -> Result<U256, ErrorObjectOwned> {
+        log::debug!("xps_nonce called");
+        let result = self
+            .contact_operations
+            .nonce(did)
+            .await
+            .map_err(RpcError::from)?;
+        Ok(result)
+    }
 }
 
 /// Error types for DID Registry JSON-RPC

--- a/lib-xps/tests/integration_test.rs
+++ b/lib-xps/tests/integration_test.rs
@@ -582,3 +582,16 @@ async fn test_did_deactivation() -> Result<(), Error> {
     })
     .await
 }
+
+#[tokio::test]
+async fn test_nonce() -> Result<(), Error> {
+    with_xps_client(None, None, |client, _, _, anvil| async move {
+        let me: LocalWallet = anvil.keys()[3].clone().into();
+
+        let nonce = client.nonce(hex::encode(me.address())).await?;
+        assert_eq!(U256::from(0), nonce);
+
+        Ok(())
+    })
+    .await
+}

--- a/registry/Cargo.toml
+++ b/registry/Cargo.toml
@@ -15,3 +15,7 @@ xps-types.workspace = true
 lib-didethresolver.workspace = true
 rustc-hex.workspace = true
 thiserror.workspace = true
+
+[dev-dependencies]
+tracing-subscriber.workspace = true
+ctor.workspace = true

--- a/registry/src/error.rs
+++ b/registry/src/error.rs
@@ -24,4 +24,6 @@ pub enum ContactOperationError<M: Middleware> {
     DIDDeactivated,
     #[error("Type failed to convert")]
     Type(#[from] lib_didethresolver::error::TypeError),
+    #[error("Error parsing hex bytes: {0}")]
+    Bytes(#[from] ethers::types::ParseBytesError),
 }

--- a/registry/src/lib.rs
+++ b/registry/src/lib.rs
@@ -173,6 +173,7 @@ where
         Ok(())
     }
 
+    /// get the nonce for a given address from [`DIDRegistry`]
     pub async fn nonce(&self, did: String) -> Result<U256, ContactOperationError<M>> {
         let address = self.resolve_did_address(did)?;
         let nonce = self.registry.nonce(address).await?;

--- a/registry/src/test.rs
+++ b/registry/src/test.rs
@@ -1,17 +1,9 @@
 //! Internal Utility functions for use in crate
-#[cfg(test)]
 use std::sync::Once;
 use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Registry};
 
-#[cfg(test)]
 static INIT: Once = Once::new();
 
-pub(crate) fn init_logging() {
-    let fmt = fmt::layer().compact();
-    Registry::default().with(env()).with(fmt).init()
-}
-
-#[cfg(test)]
 #[ctor::ctor]
 fn __init_test_logging() {
     INIT.call_once(|| {


### PR DESCRIPTION
Adds a nonce endpoint in order to sign setAttribute payloads in `libxmtp` and `xps-cli`

- adds documentation for `walletAddress`
- fixes docs in some places
- adds `nonce` endpoint & tests
- tests for `resolve_did_address`


closes #63 